### PR TITLE
Re-enable tab entry and ensure the cursor is moved the correct width

### DIFF
--- a/zee/src/components/buffer/mod.rs
+++ b/zee/src/components/buffer/mod.rs
@@ -19,7 +19,7 @@ use super::edit_tree_viewer::{
 };
 use crate::{
     editor::{
-        buffer::{BufferCursor, CursorMessage, ModifiedStatus, RepositoryRc, DISABLE_TABS},
+        buffer::{BufferCursor, CursorMessage, ModifiedStatus, RepositoryRc},
         ContextHandle,
     },
     mode::Mode,

--- a/zee/src/components/buffer/mod.rs
+++ b/zee/src/components/buffer/mod.rs
@@ -427,9 +427,7 @@ impl Component for Buffer {
 
         // Insert tab
         bindings.add("insert-tab", [Char('\t')], |this: &Self| {
-            if DISABLE_TABS {
-                this.properties.cursor.insert_tab()
-            }
+            this.properties.cursor.insert_tab()
         });
 
         // Insert character

--- a/zee/src/editor/buffer.rs
+++ b/zee/src/editor/buffer.rs
@@ -368,14 +368,18 @@ impl Buffer {
                 CursorMessage::CopySelection => self.copy_selection_to_clipboard(cursor_id),
                 CursorMessage::CutSelection => self.cut_selection_to_clipboard(cursor_id),
                 CursorMessage::InsertTab => {
-                    let tab = if DISABLE_TABS { ' ' } else { '\t' };
+                    let (tab, char_count) = if DISABLE_TABS {
+                        (' ', TAB_WIDTH)
+                    } else {
+                        ('\t', 1)
+                    };
                     let diff = self.cursors[cursor_id.0]
-                        .insert_chars(&mut self.content, std::iter::repeat(tab).take(TAB_WIDTH));
+                        .insert_chars(&mut self.content, std::iter::repeat(tab).take(char_count));
                     movement::move_horizontally(
                         &self.content,
                         &mut self.cursors[cursor_id.0],
                         Direction::Forward,
-                        TAB_WIDTH,
+                        char_count,
                     );
                     diff
                 }


### PR DESCRIPTION
Previously the `insert-tab` binding was a no-op because DISABLE_TABS
is `false` causing insert_tab() not to be run. Remove the guard around
 insert_tab() to ensure that a tab (or spaces) are outputted and
correct the calculation of the distance to move horizontally to work in
both the tab and pseudo-tab (spaces) cases.

Tested with DISABLE_TABS set to `true` (i.e. insert spaces) and `false`.