### PR TITLE
Apply `theme_index` from configuration on startup

### DIFF
--- a/zee/src/editor/mod.rs
+++ b/zee/src/editor/mod.rs
@@ -217,6 +217,9 @@ impl Component for Editor {
                 link.send(Message::SplitWindow(FlexDirection::Row));
             }
         }
+
+        let theme_index = properties.settings.theme_index;
+
         let context = ContextHandle(
             Context {
                 args_files: properties.args_files,
@@ -231,7 +234,7 @@ impl Component for Editor {
 
         Self {
             themes: &THEMES,
-            theme_index: 0,
+            theme_index,
             prompt_action: PromptAction::None,
             prompt_height: PROMPT_INACTIVE_HEIGHT,
             buffers: Buffers::new(context.clone()),


### PR DESCRIPTION
Currently the `theme_index` is always set to `0` on startup, regardless
of what is in the configuration file. `theme_index` is loaded on startup
however so apply it when creating the editor component.