### PR TITLE
Theme name in settings

### DIFF
--- a/zee/src/editor/mod.rs
+++ b/zee/src/editor/mod.rs
@@ -218,13 +218,10 @@ impl Component for Editor {
             }
         }
 
-        let mut theme_index = 0;
-        for (i, (_, name)) in THEMES.iter().enumerate() {
-            if *name == properties.settings.theme_name {
-                theme_index = i;
-                break;
-            }
-        }
+        let theme_index = THEMES
+            .iter()
+            .position(|(_, name)| *name == properties.settings.theme_name)
+            .unwrap_or(0);
 
         let context = ContextHandle(
             Context {

--- a/zee/src/editor/mod.rs
+++ b/zee/src/editor/mod.rs
@@ -218,7 +218,13 @@ impl Component for Editor {
             }
         }
 
-        let theme_index = properties.settings.theme_index;
+        let mut theme_index = 0;
+        for (i, (_, name)) in THEMES.iter().enumerate() {
+            if *name == properties.settings.theme_name {
+                theme_index = i;
+                break;
+            }
+        }
 
         let context = ContextHandle(
             Context {

--- a/zee/src/editor/mod.rs
+++ b/zee/src/editor/mod.rs
@@ -217,6 +217,9 @@ impl Component for Editor {
                 link.send(Message::SplitWindow(FlexDirection::Row));
             }
         }
+
+        let theme_index = properties.settings.theme_index;
+
         let context = ContextHandle(
             Context {
                 args_files: properties.args_files,
@@ -231,7 +234,7 @@ impl Component for Editor {
 
         Self {
             themes: &THEMES,
-            theme_index: 0,
+            theme_index,
             prompt_action: PromptAction::None,
             prompt_height: PROMPT_INACTIVE_HEIGHT,
             buffers: Buffers::new(context.clone()),

--- a/zee/src/settings.rs
+++ b/zee/src/settings.rs
@@ -10,7 +10,7 @@ use crate::error::{Context, Result};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Settings {
-    pub theme_index: usize,
+    pub theme_name: String,
 }
 
 pub fn settings_path() -> Result<PathBuf> {


### PR DESCRIPTION
Add a new property (`theme_name`) to the configuration file to contain the name of the theme. This replaces `theme_id` which contained the numeric index of the theme.

e.g.

`theme_name = "base16-material"`

versus

`theme_id = 15`

This pull request also contains the fix from #32 