### PR TITLE
Change the behaviour of the enter key in the picker

### DIFF
--- a/zee/src/components/prompt/picker.rs
+++ b/zee/src/components/prompt/picker.rs
@@ -145,10 +145,22 @@ impl Component for FilePicker {
         let initial_height = self.height();
         let input_changed = match message {
             Message::OpenFile => {
-                let path_str: Cow<str> = self.input.slice(..).into();
-                let path = PathBuf::from(path_str.trim());
-                self.properties.on_open.emit(path);
-                false
+                if let Some(path) = self.listing.selected(self.selected_index) {
+                    if path.is_dir() {
+                        self.input = path.to_string_lossy().into();
+                        ensure_trailing_newline_with_content(&mut self.input);
+                        self.cursor.move_to_end_of_line(&self.input);
+                        self.cursor.insert_char(&mut self.input, '/');
+                        self.cursor.move_right(&self.input);
+                        self.selected_index = 0;
+                        true
+                    } else {
+                        self.properties.on_open.emit(path.to_path_buf());
+                        false
+                    }
+                } else {
+                    false
+                }
             }
             Message::SelectParentDirectory => {
                 let path_str: String = self.input.slice(..).into();


### PR DESCRIPTION
Currently when selecting a file with the arrow keys in the picker and pressing
enter the file name is not added to the path resulting in the following error
being reported:
```
  Could not open file: Is a directory (os error 21)
```
Similarly, selecting a directory and pressing enter results in the same error
being displayed.

This commit changes the behaviour when enter is pressed to the following:

1.  If a file is selected, open it

2.  f a directory is selected, navigate into it and refresh the picker view

 Compared to the stock Emacs behaviours, the file selected case now matches but
 the directory selected case should result in the directory contents being
 displayed in the buffer. Zee doesn't current support this functionality but
 when/if it does this portion of the patch could change.