### PR TITLE
Support determining mode based on shebang interpreter directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "log",
  "once_cell",
  "rayon",
+ "regex",
  "serde",
  "serde_derive",
  "tree-sitter",

--- a/zee-grammar/Cargo.toml
+++ b/zee-grammar/Cargo.toml
@@ -18,6 +18,7 @@ libloading = "0.7.3"
 log = "0.4.16"
 once_cell = { version = "1.10.0", features = ["parking_lot"] }
 rayon = "1.5.2"
+regex = "1.5.5"
 serde = "1.0.136"
 serde_derive = "1.0.136"
 tree-sitter = "0.20.6"

--- a/zee-grammar/src/config.rs
+++ b/zee-grammar/src/config.rs
@@ -17,6 +17,8 @@ pub struct ModeConfig {
     pub comment: Option<CommentConfig>,
     pub indentation: IndentationConfig,
     pub grammar: Option<GrammarConfig>,
+    #[serde(default)]
+    pub shebangs: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -146,6 +146,7 @@
                 width: 4,
                 unit: Space,
             ),
+            shebangs: ["node"],
             grammar: Some(
                 Grammar(
                     id: "javascript",
@@ -248,6 +249,7 @@
                 width: 4,
                 unit: Space,
             ),
+            shebangs: ["python"],
             grammar: Some(
                 Grammar(
                     id: "python",
@@ -464,6 +466,7 @@
                 width: 2,
                 unit: Space,
             ),
+            shebangs: ["sh", "bash", "dash", "zsh"],
             grammar: Some(
                 Grammar(
                     id: "bash",

--- a/zee/src/editor/buffer.rs
+++ b/zee/src/editor/buffer.rs
@@ -173,11 +173,16 @@ impl Buffer {
         file_path: Option<PathBuf>,
         repo: Option<RepositoryRc>,
     ) -> Self {
-        let mode = file_path
-            .as_ref()
-            .map(|path| context.0.mode_by_filename(path))
+        let mode = text
+            .line(0)
+            .as_str()
+            .and_then(|shebang| context.0.mode_by_shebang(shebang))
+            .or_else(|| {
+                file_path
+                    .as_ref()
+                    .and_then(|path| context.0.mode_by_filename(path))
+            })
             .unwrap_or(&PLAIN_TEXT_MODE);
-
         let mut parser = mode
             .language()
             .and_then(|result| result.ok())

--- a/zee/src/editor/mod.rs
+++ b/zee/src/editor/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         splash::{Properties as SplashProperties, Splash},
         theme::{Theme, THEMES},
     },
-    config::{EditorConfig, PLAIN_TEXT_MODE},
+    config::EditorConfig,
     error::Result,
     task::TaskPool,
 };
@@ -94,11 +94,16 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn mode_by_filename(&self, filename: impl AsRef<Path>) -> &Mode {
+    pub fn mode_by_filename(&self, filename: impl AsRef<Path>) -> Option<&Mode> {
         self.modes
             .iter()
             .find(|&mode| mode.matches_by_filename(filename.as_ref()))
-            .unwrap_or(&PLAIN_TEXT_MODE)
+    }
+
+    pub fn mode_by_shebang(&self, shebang: &str) -> Option<&Mode> {
+        self.modes
+            .iter()
+            .find(|&mode| mode.matches_by_shebang(shebang))
     }
 }
 


### PR DESCRIPTION
Attempt to determine the appropriate mode based on the presence of an interpreter directive on the first line of the file. Interpreter directives are examined first, followed by the filename when determining the mode mirroring what Emacs does by default.

Reopening now that `highlight-with-queries` has been merged. Feel free to close if there is no interest in supporting this feature.