### PR TITLE
Change TAB to use the mode-specific indentation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Unreleased
+
+## Added
+
+- Change TAB to use the mode-specific indentation config (#49)
+- A new configuration system with a new file `config.ron` was introduced. The
+  available modes and tree sitter parsers are now configurable at runtime,
+  without having to rebuild the editor. (#29)
+- The ability to specify the theme by name rather than index in the
+  configuration file
+- Added a changelog to be updated timely as PRs are merged
+
+## Breaking
+
+-
+
+## Bug Fixes
+
+- Actually use the theme specified in the configuration file.
+- Re-enable tab entry and ensure the cursor is moved the correct width (#31)
+
+# v0.3.2 and before
+
+- The tree sitter parsers are now linked dynamically and built by `zee` itself
+  rather than as part of the build process. In the future, this will enable
+  configuring the tree sitters parser.
+
+TODO: write some more general notes about the early days of zee

--- a/zee-edit/src/graphemes.rs
+++ b/zee-edit/src/graphemes.rs
@@ -2,18 +2,16 @@ use ropey::{iter::Chunks, str_utils, Rope, RopeSlice};
 use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete};
 use unicode_width::UnicodeWidthStr;
 
-use super::TAB_WIDTH;
-
 pub type ByteIndex = usize;
 pub type CharIndex = usize;
 pub type LineIndex = usize;
 
-pub fn width(slice: &RopeSlice) -> usize {
+pub fn width(tab_width: usize, slice: &RopeSlice) -> usize {
     rope_slice_as_str(slice, |text| {
         if text == "\t" {
-            TAB_WIDTH
+            tab_width
         } else {
-            text.chars().filter(|character| *character == '\t').count() * TAB_WIDTH
+            text.chars().filter(|character| *character == '\t').count() * tab_width
                 + UnicodeWidthStr::width(text)
         }
     })

--- a/zee-edit/src/lib.rs
+++ b/zee-edit/src/lib.rs
@@ -13,8 +13,6 @@ pub use self::{
     movement::Direction,
 };
 
-pub const TAB_WIDTH: usize = 4;
-
 trait RopeCursorExt {
     fn cursor_to_line(&self, cursor: &Cursor) -> usize;
 
@@ -98,9 +96,9 @@ impl Cursor {
         }
     }
 
-    pub fn column_offset(&self, text: &Rope) -> usize {
+    pub fn column_offset(&self, tab_width: usize, text: &Rope) -> usize {
         let char_line_start = text.line_to_char(text.cursor_to_line(self));
-        graphemes::width(&text.slice(char_line_start..self.range.start))
+        graphemes::width(tab_width, &text.slice(char_line_start..self.range.start))
     }
 
     pub fn reconcile(&mut self, new_text: &Rope, diff: &OpaqueDiff) {

--- a/zee-edit/src/movement.rs
+++ b/zee-edit/src/movement.rs
@@ -26,7 +26,13 @@ pub fn move_horizontally(text: &Rope, cursor: &mut Cursor, direction: Direction,
 
 /// Move the cursor vertically in the specified direction by `count` lines
 #[inline]
-pub fn move_vertically(text: &Rope, cursor: &mut Cursor, direction: Direction, count: usize) {
+pub fn move_vertically(
+    text: &Rope,
+    cursor: &mut Cursor,
+    tab_width: usize,
+    direction: Direction,
+    count: usize,
+) {
     // The maximum possible line index in the text
     let max_line_index = text.len_lines().saturating_sub(1);
 
@@ -58,7 +64,7 @@ pub fn move_vertically(text: &Rope, cursor: &mut Cursor, direction: Direction, c
     let current_visual_x = cursor.visual_horizontal_offset.get_or_insert_with(|| {
         let current_line_start = text.line_to_char(current_line_index);
         let line_to_cursor = text.slice(current_line_start..cursor.range.start);
-        crate::graphemes::width(&line_to_cursor)
+        crate::graphemes::width(tab_width, &line_to_cursor)
     });
 
     let new_line = text.line(new_line_index);
@@ -66,7 +72,7 @@ pub fn move_vertically(text: &Rope, cursor: &mut Cursor, direction: Direction, c
     let mut new_visual_x = 0;
     let mut char_offset = text.line_to_char(new_line_index);
     for grapheme in &mut graphemes {
-        let width = crate::graphemes::width(&grapheme);
+        let width = crate::graphemes::width(tab_width, &grapheme);
         if new_visual_x + width > *current_visual_x || grapheme.slice == "\n" {
             break;
         }

--- a/zee-grammar/src/config.rs
+++ b/zee-grammar/src/config.rs
@@ -32,6 +32,26 @@ pub struct IndentationConfig {
     pub unit: IndentationUnit,
 }
 
+impl IndentationConfig {
+    pub fn to_char(&self) -> char {
+        self.unit.to_char()
+    }
+
+    pub fn char_count(&self) -> usize {
+        match self.unit {
+            IndentationUnit::Space => self.width,
+            IndentationUnit::Tab => 1,
+        }
+    }
+
+    pub fn tab_width(&self) -> usize {
+        match self.unit {
+            IndentationUnit::Space => 1,
+            IndentationUnit::Tab => self.width,
+        }
+    }
+}
+
 impl Default for IndentationConfig {
     fn default() -> Self {
         Self {
@@ -45,6 +65,15 @@ impl Default for IndentationConfig {
 pub enum IndentationUnit {
     Space,
     Tab,
+}
+
+impl IndentationUnit {
+    pub fn to_char(&self) -> char {
+        match self {
+            Self::Space => ' ',
+            Self::Tab => '\t',
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/zee/src/components/buffer/mod.rs
+++ b/zee/src/components/buffer/mod.rs
@@ -261,7 +261,11 @@ impl Component for Buffer {
         // The "status bar" which shows information about the file etc.
         let status_bar = StatusBar::with(StatusBarProperties {
             current_line_index: content.char_to_line(self.properties.cursor.inner().range().start),
-            column_offset: self.properties.cursor.inner().column_offset(&content),
+            column_offset: self
+                .properties
+                .cursor
+                .inner()
+                .column_offset(self.properties.mode.indentation.tab_width(), &content),
             file_path: self.properties.file_path.clone(),
             focused: self.properties.focused,
             frame_id: self.properties.frame_id,

--- a/zee/src/components/buffer/textarea.rs
+++ b/zee/src/components/buffer/textarea.rs
@@ -179,7 +179,8 @@ impl TextArea {
                 scope,
                 is_error,
             );
-            let grapheme_width = zee_edit::graphemes::width(&grapheme);
+            let grapheme_width =
+                zee_edit::graphemes::width(self.properties.mode.indentation.tab_width(), &grapheme);
             let horizontal_bounds_inclusive = frame.min_x()..=frame.max_x();
             if !horizontal_bounds_inclusive.contains(&(visual_x + grapheme_width)) {
                 break;

--- a/zee/src/editor/buffer.rs
+++ b/zee/src/editor/buffer.rs
@@ -11,7 +11,6 @@ use zi::ComponentLink;
 
 use zee_edit::{
     graphemes::strip_trailing_whitespace, movement, tree::EditTree, Cursor, Direction, OpaqueDiff,
-    TAB_WIDTH,
 };
 use zee_grammar::Mode;
 
@@ -312,12 +311,20 @@ impl Buffer {
             let cursor = &mut self.cursors[cursor_id.0];
             // Stateless
             match message {
-                CursorMessage::Up(n) => {
-                    movement::move_vertically(content, cursor, Direction::Backward, n)
-                }
-                CursorMessage::Down(n) => {
-                    movement::move_vertically(content, cursor, Direction::Forward, n)
-                }
+                CursorMessage::Up(n) => movement::move_vertically(
+                    content,
+                    cursor,
+                    self.mode.indentation.tab_width(),
+                    Direction::Backward,
+                    n,
+                ),
+                CursorMessage::Down(n) => movement::move_vertically(
+                    content,
+                    cursor,
+                    self.mode.indentation.tab_width(),
+                    Direction::Forward,
+                    n,
+                ),
                 CursorMessage::Left => {
                     movement::move_horizontally(content, cursor, Direction::Backward, 1)
                 }
@@ -373,25 +380,32 @@ impl Buffer {
                 CursorMessage::CopySelection => self.copy_selection_to_clipboard(cursor_id),
                 CursorMessage::CutSelection => self.cut_selection_to_clipboard(cursor_id),
                 CursorMessage::InsertTab => {
-                    let (tab, char_count) = if DISABLE_TABS {
-                        (' ', TAB_WIDTH)
-                    } else {
-                        ('\t', 1)
-                    };
-                    let diff = self.cursors[cursor_id.0]
-                        .insert_chars(&mut self.content, std::iter::repeat(tab).take(char_count));
+                    let (indentation_unit, indentation_count) = (
+                        self.mode.indentation.to_char(),
+                        self.mode.indentation.char_count(),
+                    );
+                    let diff = self.cursors[cursor_id.0].insert_chars(
+                        &mut self.content,
+                        std::iter::repeat(indentation_unit).take(indentation_count),
+                    );
                     movement::move_horizontally(
                         &self.content,
                         &mut self.cursors[cursor_id.0],
                         Direction::Forward,
-                        char_count,
+                        indentation_count,
                     );
                     diff
                 }
                 CursorMessage::InsertNewLine => {
                     let diff = self.cursors[cursor_id.0].insert_char(&mut self.content, '\n');
                     let cursor = &mut self.cursors[cursor_id.0];
-                    movement::move_vertically(&self.content, cursor, Direction::Forward, 1);
+                    movement::move_vertically(
+                        &self.content,
+                        cursor,
+                        self.mode.indentation.tab_width(),
+                        Direction::Forward,
+                        1,
+                    );
                     movement::move_to_start_of_line(&self.content, cursor);
                     diff
                 }
@@ -789,5 +803,3 @@ impl std::ops::Deref for RepositoryRc {
         &self.0
     }
 }
-
-pub const DISABLE_TABS: bool = false;


### PR DESCRIPTION
#29 added mode-specific configuration for indentation, though it remained unused. See the `indentation` field for an example below. This PR changes `TAB` to respect the indentation configuration.

```
        Mode(
            name: "C",
            scope: "source.c",
            injection_regex: "c",
            patterns: [Suffix(".c"), Suffix(".h")],
            comment: Some(Comment(token: "// ")),
            indentation: Indentation(
                width: 4,
                unit: Space,
            ),
            grammar: Some(
                Grammar(
                    id: "c",
                    source: Git(
                        git: "https://github.com/tree-sitter/tree-sitter-c",
                        rev: "517bf92b2c5e8baa4241cbb8a49085ed7c3c48d4",
                    ),
                )
            ),
        ),

```
