### PR TITLE
Add a configuration parameter for trimming whitespace on save

### DIFF
--- a/zee/build.rs
+++ b/zee/build.rs
@@ -12,6 +12,8 @@ pub struct EditorConfig {
     #[serde(default)]
     pub theme: String,
     pub modes: Vec<ModeConfig>,
+    #[serde(default)]
+    pub trim_trailing_whitespace_on_save: bool,
 }
 
 fn main() -> Result<()> {

--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -1,6 +1,9 @@
 (
     // Which theme to use
     theme: "zee-gruvbox",
+    // Remove trailing whitespace on all lines when saving.
+    // Allowed values: `true` or `false`. Default: `true`
+    trim_trailing_whitespace_on_save: true,
 
     // Modes and tree sitter parsers
     //

--- a/zee/src/config.rs
+++ b/zee/src/config.rs
@@ -13,6 +13,10 @@ pub struct EditorConfig {
     #[serde(default)]
     pub theme: String,
     pub modes: Vec<ModeConfig>,
+    /// Remove whitespace from the end of lines when saving. On large files this could negatively
+    /// impact performance. Default: `true`.
+    #[serde(default)]
+    pub trim_trailing_whitespace_on_save: bool,
 }
 
 impl Default for EditorConfig {

--- a/zee/src/editor/buffer.rs
+++ b/zee/src/editor/buffer.rs
@@ -518,12 +518,17 @@ impl Buffer {
             let text = self.content.staged().clone();
             let file_path = file_path.clone();
             let link = self.context.link.clone();
+            let trim_trailing_whitespace = self.context.config.trim_trailing_whitespace_on_save;
             self.context.task_pool.spawn(move |_| {
+                let text = match trim_trailing_whitespace {
+                    true => strip_trailing_whitespace(text),
+                    false => text,
+                };
+
                 let buffer_message = BufferMessage::SaveBufferEnd(
                     File::create(&file_path)
                         .map(BufWriter::new)
                         .and_then(|writer| {
-                            let text = strip_trailing_whitespace(text);
                             text.write_to(writer)?;
                             Ok(text)
                         }),


### PR DESCRIPTION
Prior to this change trailing whitespace is always remove when a file is saved. This can be expensive for very large files and in some cases may not be wanted by the user. Add a new configuration parameter `trim_trailing_whitespace_on_save` to allow the user to change the behaviour globally.

This change also moves the call to `strip_trailing_whitespace()` before the call to `File::create` reducing the amount of time that between when the file has been truncated and when the contents are written back. 