### PR TITLE
Fix tree sitter spans not being aligned with text after saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#32](https://github.com/zee-editor/zee/pull/32)
 - Re-enable tab entry and ensure the cursor is moved the correct width
   [#31](https://github.com/zee-editor/zee/pull/31)
+- Fix tree sitter spans not being aligned with text after saving
+  [#65](https://github.com/zee-editor/zee/pull/65)
 
 ## v0.3.2 - 2022-04-23
 

--- a/zee/src/syntax/parse.rs
+++ b/zee/src/syntax/parse.rs
@@ -160,7 +160,7 @@ impl ParserPool {
 
         // If the parser task hasn't been cancelled, store the new syntax tree
         if let Some(ParsedSyntax { tree, text }) = parsed {
-            assert!(tree.root_node().end_byte() <= text.len_bytes());
+            assert!(tree.root_node().end_byte() == text.len_bytes());
             self.tree = Some(ParseTree { version, tree });
         }
     }


### PR DESCRIPTION
This PR ensures that after saving a buffer, we recreate a fresh copy of the tree sitter parser. 

Context: on save, we strip white-space which causes the tree sitter AST spans to not be aligned with the text any more. This is the bug reported in #42. 

We are typically able to compute diffs incrementally as the buffer is edited and update the tree sitter parser accordingly. We could probably compute the diffs for the `strip_trailing_whitespace` function. However, in general it's expected that on save a `linter` or similar would be run. This makes updating the tree sitter parsers impractical.

The solution in this PR is to compute a fresh copy of the AST. This means we can run any arbitrary transformation of the text on save, without having to create a diff to update the parsers. However, the downside is that it means we need to remove the existing tree on save. 

IMPORTANT: As the new tree is computed async-ly, there's (a short) period when there's no available tree. This **causes some flickering** on save which is not ideal. 

@kevinmatthes @iainh Thank you for your investigations and patience.

Fixes #42 
Based on #64 