### PR TITLE
Introduce a new interactive message prompt type

### DIFF
--- a/zee/src/components/prompt/interactive.rs
+++ b/zee/src/components/prompt/interactive.rs
@@ -1,0 +1,68 @@
+use std::borrow::Cow;
+
+use zi::{
+    components::text::{Text, TextProperties},
+    prelude::*,
+    Callback,
+};
+
+use super::Theme;
+
+// Message type handled by the `InteractiveMessage` component
+#[derive(Clone, Copy, PartialEq)]
+pub enum Message {
+    Accept,
+    Decline,
+}
+
+pub struct Properties {
+    pub theme: Cow<'static, Theme>,
+    pub on_input: Callback<bool>,
+    pub message: String,
+}
+
+pub struct InteractiveMessage {
+    properties: Properties,
+}
+
+impl Component for InteractiveMessage {
+    type Message = Message;
+
+    type Properties = Properties;
+
+    fn create(properties: Self::Properties, _frame: Rect, _link: ComponentLink<Self>) -> Self {
+        Self { properties }
+    }
+
+    fn view(&self) -> Layout {
+        let message = format!("{} (y/n)", self.properties.message);
+        Text::with(
+            TextProperties::new()
+                .style(self.properties.theme.input)
+                .content(message),
+        )
+    }
+
+    fn update(&mut self, message: Self::Message) -> ShouldRender {
+        self.properties.on_input.emit(message == Message::Accept);
+        ShouldRender::No
+    }
+
+    fn bindings(&self, bindings: &mut Bindings<Self>) {
+        if !bindings.is_empty() {
+            return;
+        }
+
+        // Set focus to `true` in order to react to key presses
+        bindings.set_focus(true);
+
+        bindings
+            .command("accept", || Message::Accept)
+            .with([Key::Char('y')]);
+
+        bindings
+            .command("decline", || Message::Decline)
+            .with([Key::Esc])
+            .with([Key::Char('n')]);
+    }
+}

--- a/zee/src/components/prompt/mod.rs
+++ b/zee/src/components/prompt/mod.rs
@@ -4,6 +4,8 @@ pub mod picker;
 mod matcher;
 mod status;
 
+mod interactive;
+
 use std::{borrow::Cow, path::PathBuf};
 use zi::{
     components::text::{Text, TextProperties},
@@ -15,6 +17,7 @@ use crate::editor::{BufferId, ContextHandle};
 
 use self::{
     buffers::{BufferEntry, BufferPicker, Properties as BufferPickerProperties},
+    interactive::{InteractiveMessage, Properties as InteractiveMessageProperties},
     picker::{FilePicker, FileSource, Properties as FilePickerProperties},
 };
 
@@ -47,6 +50,10 @@ pub enum Action {
         source: FileSource,
         on_open: Callback<PathBuf>,
         on_change_height: Callback<usize>,
+    },
+    InteractiveMessage {
+        message: Cow<'static, str>,
+        on_input: Callback<bool>,
     },
 }
 
@@ -141,6 +148,13 @@ impl Component for Prompt {
                 on_open: on_open.clone(),
                 on_change_height: on_change_height.clone(),
             }),
+            Action::InteractiveMessage { on_input, message } => {
+                InteractiveMessage::with(InteractiveMessageProperties {
+                    theme: self.properties.theme.clone(),
+                    on_input: on_input.clone(),
+                    message: message.to_string(),
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
Add a new type of prompt that displays a message to the user and accepts either 'y' (yes) or 'n' (no) as input.

This PR also adds in interactive prompt to the quit message to avoid exiting while files are in a non-saved state similar to what was described in #58.