### PR TITLE
Tab width should always be the configured indentation width

### DIFF
--- a/zee-grammar/src/config.rs
+++ b/zee-grammar/src/config.rs
@@ -45,10 +45,7 @@ impl IndentationConfig {
     }
 
     pub fn tab_width(&self) -> usize {
-        match self.unit {
-            IndentationUnit::Space => 1,
-            IndentationUnit::Tab => self.width,
-        }
+        self.width
     }
 }
 


### PR DESCRIPTION
`tab_width()` should return the configured indentation width to appear visually as the correct size regardless of the mode's configured indentation unit.

This resolves the issue reported in #71.