### PR TITLE
[Bugfix] Add SCons support

### DIFF
--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -277,6 +277,7 @@
             scope: "source.python",
             injection_regex: "python",
             patterns: [
+                Name("SConstruct"),
                 Suffix(".py"),
                 Suffix(".py3"),
                 Suffix(".py2"),


### PR DESCRIPTION
SCons is a build system which is based upon Python scripts named `SConstruct` and describes itself as a replacement for `make`.  Despite the fact that those `SConstruct` scripts typically carry a shebang (#40), it might be a good idea highlighting them anyway with the Python grammar, by default.

This Pull Request adds support for the SCons build step specification to the default configuration file.