### PR TITLE
[Bugfix] Activate Unused Colour (#5)

### DIFF
--- a/zee/src/components/theme/base16.rs
+++ b/zee/src/components/theme/base16.rs
@@ -33,9 +33,6 @@ pub struct Base16Theme {
     /// Any text to be displayed in the status bar which is not coloured by
     /// applying the respective configured values from one of the fields will be
     /// displayed using this colour.
-    ///
-    /// Furthermore, when identifying a syntactical issue, the corresponding
-    /// section will be underlined and highlighted using this colour.
     pub base04: Colour,
 
     /// The variables' colour.
@@ -47,7 +44,7 @@ pub struct Base16Theme {
     /// The cursor's colour.
     pub base06: Colour,
 
-    /// Currently unused.
+    /// The background colour for important status bar fields.
     pub base07: Colour,
 
     /// Keywords of the coding language.
@@ -646,10 +643,7 @@ pub const VSCODE_DARK: Base16Theme = Base16Theme {
     base04: Colour::rgb(0x00, 0x7A, 0xCC),
     base05: Colour::rgb(0x9C, 0xDC, 0xFE),
     base06: Colour::rgb(0xFF, 0xFF, 0xFF),
-
-    // Currently unused.
-    base07: Colour::rgb(0x00, 0x00, 0x00),
-
+    base07: Colour::rgb(0x20, 0x20, 0x20),
     base08: Colour::rgb(0x56, 0x9C, 0xD6),
     base09: Colour::rgb(0xD2, 0x1A, 0x25),
     base0a: Colour::rgb(0x4E, 0xC9, 0xB0),

--- a/zee/src/components/theme/mod.rs
+++ b/zee/src/components/theme/mod.rs
@@ -196,7 +196,7 @@ impl Theme {
             // Light Foreground (Not often used)
             base06: light_foreground,
             // Light Background (Not often used)
-            base07: _light_background,
+            base07: light_background,
             // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
             base08: variables,
             // Integers, Boolean, Constants, XML Attributes, Markup Link Url
@@ -250,8 +250,8 @@ impl Theme {
                     base: normal(lighter_background, default_background),
                     frame_id_focused: normal(functions, default_background),
                     frame_id_unfocused: normal(comments, default_background),
-                    is_modified: normal(lighter_background, constants),
-                    is_not_modified: normal(lighter_background, comments),
+                    is_modified: normal(light_background, constants),
+                    is_not_modified: normal(light_background, comments),
                     file_name: bold(lighter_background, strings),
                     file_size: normal(lighter_background, dark_foreground),
                     position_in_file: normal(lighter_background, dark_foreground),


### PR DESCRIPTION
This is the essence of #80.  The changes will activate the previously unused colour `base07` of `Base16Theme`.