### PR TITLE
[Enhancement] Add Support for Just

### DIFF
--- a/zee-grammar/src/config.rs
+++ b/zee-grammar/src/config.rs
@@ -125,6 +125,8 @@ pub enum GrammarSource {
         remote: String,
         #[serde(rename = "rev")]
         revision: String,
+        #[serde(default, rename = "scm")]
+        scheme_dir: Option<String>,
         path: Option<PathBuf>,
     },
 }

--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -225,6 +225,32 @@
             ),
         ),
 
+        // Just Build System
+        Mode(
+            name: "Just Build System",
+            scope: "source.justfile",
+            injection_regex: "justfile",
+            patterns: [
+                Name(".justfile"),
+                Name("justfile"),
+            ],
+            comment: Some(Comment(token: "# ")),
+            indentation: Indentation(
+                width: 4,
+                unit: Space,
+            ),
+            grammar: Some(
+                Grammar(
+                    id: "just",
+                    source: Git(
+                        git: "https://github.com/IndianBoy42/tree-sitter-just",
+                        rev: "8af0aab79854aaf25b620a52c39485849922f766",
+                        scm: Some("queries/just"),
+                    ),
+                )
+            ),
+        ),
+
         // Markdown
         Mode(
             name: "Markdown",


### PR DESCRIPTION
This Pull Request adds support for the [Just Build System](https://github.com/casey/just) and, furthermore, an emergency override option for the path to the respective `*.scm` files.

The highlighting in Zee is based upon Tree-Sitters which need highlighting instruction files named `highlights.scm`.  Previously, they are fetched from their source repositories **then and only then** if they are stored in the directory `queries`.  The source repository of the Tree-Sitter for the Just Build System, in contrast, stores its `*.scm`s in the directory `queries/just` and would, hence, not be fetched correctly when building.  This Pull Request challenges this problem by the introduction of an overriding field for the default query directory.  This field can be omitted when the assumptions of Zee are fulfilled.