### PR TITLE
[Bugfix] Fix Tree-Sitter Queries

### DIFF
--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -459,9 +459,9 @@
             ),
         ),
 
-        // Tree sitter queries
+        // Tree-Sitter Queries
         Mode(
-            name: "tsq",
+            name: "Tree-Sitter Query",
             scope: "source.tsq",
             injection_regex: "tsq",
             patterns: [Suffix(".scm")],

--- a/zee/config/queries/rust/highlights.scm
+++ b/zee/config/queries/rust/highlights.scm
@@ -101,9 +101,9 @@
 (arguments
   (identifier) @variable.parameter)
 (parameter
-	pattern: (identifier) @variable.parameter)
+  pattern: (identifier) @variable.parameter)
 (closure_parameters
-	(identifier) @variable.parameter)
+  (identifier) @variable.parameter)
 
 
 


### PR DESCRIPTION
This Pull Request fixes some minor typos in the `highlights.scm` for Rust and renames the Tree-Sitter-specific configuration language mode such that it is displayed in a nicer way when editing.