### PR TITLE
[Bugfix] Highlight Cabal with Haskell

### DIFF
--- a/zee/config/config.ron
+++ b/zee/config/config.ron
@@ -131,6 +131,8 @@
             scope: "source.haskell",
             injection_regex: "haskell",
             patterns: [
+                Name("cabal.project"),
+                Suffix(".cabal"),
                 Suffix(".hs"),
             ],
             comment: Some(Comment(token: "-- ")),


### PR DESCRIPTION
Just as Cargo is the default package and build manager for Rust, Cabal is the one for Haskell.  This Pull Request adds highlighting support for Cabal-related configuration files using the already supported Haskell Tree-Sitter and its `highlights.scm`.